### PR TITLE
Disable rustfmt merge_imports feature

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,4 @@
 reorder_imports = true
-merge_imports = true
+
+# Disabled until stable or unstable features can be used with stable rust
+# merge_imports = true


### PR DESCRIPTION
## Description

Add a brief summary of your PR here, between one sentence and two paragraphs

## Additions

- Detail API additions here if any
- Do not list changes or removals

## Removals

- List API removals here if any

## Modifications

- List changes to existing structures and functions here if any

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
